### PR TITLE
Adding AllowAdminCreateUserOnly To Block Anon User Creation

### DIFF
--- a/waf-dashboard.yaml
+++ b/waf-dashboard.yaml
@@ -178,6 +178,8 @@ Resources:
     Type: AWS::Cognito::UserPool
     Properties:
       UserPoolName: 'WAFKibanaUsers'
+      AdminCreateUserConfig:
+        AllowAdminCreateUserOnly: True
       UsernameAttributes:
         - email
       AutoVerifiedAttributes:


### PR DESCRIPTION
*Issue #, if available:* 1

*Description of changes:*  Adding AllowAdminCreateUserOnly to Cognito User Pool.  Otherwise anybody that finds the site can click signup and conduct recon on site and traffic


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
